### PR TITLE
一部コマンドの互換性のためにtootにperma_linkメソッドを生やす

### DIFF
--- a/model.rb
+++ b/model.rb
@@ -32,5 +32,9 @@ class MstdnToot < Retriever::Model
   field.has    :user, MstdnUser, required: true
 
   entity_class Retriever::Entity::URLEntity
+
+  def perma_link
+    link
+  end
 end
 


### PR DESCRIPTION
core/plugin/quoted_message/quoted_message.rb の :copy_tweet_url など、perma_linkメソッドを要求するものに対応できるようになります。