### PR TITLE
Try deferred

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+source 'https://rubygems.org'
+
 gem "eventmachine"
 gem "faye-websocket"
 gem "nokogiri"

--- a/create_notification.rb
+++ b/create_notification.rb
@@ -3,10 +3,10 @@ def create_notification(json)
 
   case data["type"]
     when "favourite" then
-      user_name =  if data["status"]["account"] ["display_name"].empty?
-        data["status"]["account"] ["username"]
+      user_name =  if data["status"]["account"]["display_name"].empty?
+        data["status"]["account"]["username"]
       else
-        data["status"]["account"] ["display_name"]
+        data["status"]["account"]["display_name"]
       end
 
       if !(data["status"]["spoiler_text"].empty?)
@@ -35,10 +35,10 @@ def create_notification(json)
       activity :mstdn_fav, "#{parse_name(data)}さんにふぁぼられました。\n\n#{user_name}: #{toot_body}"
 
     when "reblog" then
-      user_name =  if data["status"]["account"] ["display_name"].empty?
-        data["status"]["account"] ["username"]
+      user_name =  if data["status"]["account"]["display_name"].empty?
+        data["status"]["account"]["username"]
       else
-        data["status"]["account"] ["display_name"]
+        data["status"]["account"]["display_name"]
       end
 
       if !(data["status"]["spoiler_text"].empty?)

--- a/create_toot.rb
+++ b/create_toot.rb
@@ -35,18 +35,18 @@ def create_toot(status)
 
   end
 
-  user_name = if data["account"] ["display_name"].empty?
-    data["account"] ["username"]
+  user_name = if data["account"]["display_name"].empty?
+    data["account"]["username"]
   else
-    data["account"] ["display_name"]
+    data["account"]["display_name"]
   end
 
 
   user = MstdnUser.new_ifnecessary(
     name: user_name,
-    link: data["account"] ["url"],
-    created: Time.parse(data["account"] ["created_at"]).localtime,
-    profile_image_url: data["account"] ["avatar"],
+    link: data["account"]["url"],
+    created: Time.parse(data["account"]["created_at"]).localtime,
+    profile_image_url: data["account"]["avatar"],
     id: data["account"]["id"].to_i,
     idname: data["account"]["acct"]
   )

--- a/mikutodon.rb
+++ b/mikutodon.rb
@@ -78,8 +78,8 @@ Plugin.create(:mikutodon) do
           visible: true,
           role: :timeline) do |opt|
     opt.messages.select { |_| _.is_a?(MstdnToot) }.each { |message|
-      Thread.new {
-        mstdn_fav(message[:id], account)
+      mstdn_fav(message[:id], account).trap { |err|
+        error err
       }
     }
   end
@@ -94,8 +94,8 @@ Plugin.create(:mikutodon) do
           visible: true,
           role: :timeline) do |opt|
     opt.messages.select { |_| _.is_a?(MstdnToot) }.each { |message|
-      Thread.new {
-        mstdn_reblog(message[:id], account)
+      mstdn_reblog(message[:id], account).trap { |err|
+        error err
       }
     }
   end
@@ -122,9 +122,9 @@ Plugin.create(:mikutodon) do
     end
 
     text = Plugin.create(:gtk).widgetof(opt.widget).widget_post.buffer.text
-    post_toot(text, cw_text, account, UserConfig[:mastodon_vis])
-
-    Plugin.create(:gtk).widgetof(opt.widget).widget_post.buffer.text = ""
+    post_toot(text, cw_text, account, UserConfig[:mastodon_vis]).next {
+      Plugin.create(:gtk).widgetof(opt.widget).widget_post.buffer.text = ""
+    }
   end
 
 
@@ -164,12 +164,12 @@ Plugin.create(:mikutodon) do
       activity :mikutodon_debug_message, "正規表現だよ！"
     end
 
-    post_toot(text, cw, account, UserConfig[:mastodon_vis])
+    post_toot(text, cw, account, UserConfig[:mastodon_vis]).next {
+      Plugin.create(:gtk).widgetof(opt.widget).widget_post.buffer.text = ""
+    }
 
 
 #    end
-
-    Plugin.create(:gtk).widgetof(opt.widget).widget_post.buffer.text = ""
   end
 
   # タイムラインの開始を開始

--- a/mikutodon.rb
+++ b/mikutodon.rb
@@ -67,7 +67,7 @@ Plugin.create(:mikutodon) do
   end
 
 
-# ふぁぼふぁぼこまんど
+  # ふぁぼふぁぼこまんど
   command(:mastodon_fav,
           name: "お気に入り",
           condition: lambda{ |opt|
@@ -108,7 +108,7 @@ Plugin.create(:mikutodon) do
     timeline_start(account)
   end
 
-# CWで投稿するコマンドを追加
+  # CWで投稿するコマンドを追加
   command(:mastodon_cw,
           name: "CWで投稿",
           condition: lambda{ |opt| true },
@@ -129,7 +129,7 @@ Plugin.create(:mikutodon) do
 
 
 
-# Mastodonに投稿
+  # Mastodonに投稿
   command(:mastodon_toot,
           name: "Mastodonに投稿する",
           condition: lambda{ |opt| true },

--- a/mikutodon.rb
+++ b/mikutodon.rb
@@ -123,7 +123,10 @@ Plugin.create(:mikutodon) do
 
     text = Plugin.create(:gtk).widgetof(opt.widget).widget_post.buffer.text
     post_toot(text, cw_text, account, UserConfig[:mastodon_vis]).next {
+      # 投稿成功時のみバッファをクリア
       Plugin.create(:gtk).widgetof(opt.widget).widget_post.buffer.text = ""
+    }.trap { |err|
+      error err
     }
   end
 
@@ -165,7 +168,10 @@ Plugin.create(:mikutodon) do
     end
 
     post_toot(text, cw, account, UserConfig[:mastodon_vis]).next {
+      # 投稿成功時のみバッファをクリア
       Plugin.create(:gtk).widgetof(opt.widget).widget_post.buffer.text = ""
+    }.trap { |err|
+      error err
     }
 
 

--- a/orig_parse.rb
+++ b/orig_parse.rb
@@ -1,7 +1,7 @@
 def parse_name(data)
-  if data["account"] ["display_name"].empty?
-    return data["account"] ["username"]
+  if data["account"]["display_name"].empty?
+    return data["account"]["username"]
   else
-    return data["account"] ["display_name"]
+    return data["account"]["display_name"]
   end
 end

--- a/stream.rb
+++ b/stream.rb
@@ -3,32 +3,32 @@ def stream(account, tl, tl_name, toots)
     ws = Faye::WebSocket::Client.new(
       "wss://#{account[:host]}/api/v1/streaming?access_token=#{account[:token]}&stream=#{tl}",
     )
-      ws.on :open do |e|
-        activity :mikutodon_debug_message, "こねくと！"
-        $tl_close = false
-      end
+    ws.on :open do |e|
+      activity :mikutodon_debug_message, "こねくと！"
+      $tl_close = false
+    end
 
-      ws.on :error do |e|
-        activity :mikutodon_debug_message, "えらー！\n#{e}"
-      end
+    ws.on :error do |e|
+      activity :mikutodon_debug_message, "えらー！\n#{e}"
+    end
 
-      ws.on :close do |e|
-        puts "connection close."
-        puts e
-        activity :mikutodon_debug_message, "こねくしょんくろーず！"
-        $tl_close = true
-      end
+    ws.on :close do |e|
+      puts "connection close."
+      puts e
+      activity :mikutodon_debug_message, "こねくしょんくろーず！"
+      $tl_close = true
+    end
 
-      ws.on :message do |msg|
-        toot = JSON.parse(msg.data)
-        if toot["event"] == "update"
-          Plugin.call :extract_receive_message, tl_name, create_toot(toot["payload"])
-        elsif toot["event"] == "notification"
-          create_notification(toot["payload"])
-        else
-          puts toot
-        end
+    ws.on :message do |msg|
+      toot = JSON.parse(msg.data)
+      if toot["event"] == "update"
+        Plugin.call :extract_receive_message, tl_name, create_toot(toot["payload"])
+      elsif toot["event"] == "notification"
+        create_notification(toot["payload"])
+      else
+        puts toot
       end
+    end
   end
 end
 

--- a/toot_operation.rb
+++ b/toot_operation.rb
@@ -1,7 +1,7 @@
 def mstdn_fav(id, account)
   toot = toot_test(id, account)
 
-  if !(toot["body"] ["favourited"])
+  if !(toot["body"]["favourited"])
     uri = URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/favourite")
   else
     uri = URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/unfavourite")
@@ -27,7 +27,7 @@ end
 def mstdn_reblog(id, account)
   toot = toot_test(id, account)
 
-  if !(toot["body"] ["reblogged"])
+  if !(toot["body"]["reblogged"])
     uri = URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/reblog")
   else
     uri = URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/unreblog")

--- a/toot_operation.rb
+++ b/toot_operation.rb
@@ -1,126 +1,110 @@
 def mstdn_fav(id, account)
-  toot = toot_test(id, account)
+  toot_test(id, account).next { |toot|
+    uri = if !(toot[:body]["favourited"])
+            URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/favourite")
+          else
+            URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/unfavourite")
+          end
 
-  if !(toot["body"]["favourited"])
-    uri = URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/favourite")
-  else
-    uri = URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/unfavourite")
-  end
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
 
-  https = Net::HTTP.new(uri.host, uri.port)
-  https.use_ssl = true
+    req = Net::HTTP::Post.new(uri.request_uri)
 
-  req = Net::HTTP::Post.new(uri.request_uri)
+    req["Authorization"] = "Bearer #{account[:token]}"
 
-  token = " Bearer " + account[:token]
-
-  req["Authorization"] = token
-
-
-  res = https.request(req)
-
-  mikutodon_is_error?(res, "fav")
-  # activity :mikutodon_debug_message, "fav: #{res.code} #{res.message}"
+    https.request(req)
+  }.next { |res|
+    mikutodon_is_error?(res, "fav")
+    # activity :mikutodon_debug_message, "fav: #{res.code} #{res.message}"
+  }
 end
 
 
 def mstdn_reblog(id, account)
-  toot = toot_test(id, account)
+  toot_test(id, account).next { |toot|
+    uri = if !(toot[:body]["reblogged"])
+            URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/reblog")
+          else
+            URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/unreblog")
+          end
 
-  if !(toot["body"]["reblogged"])
-    uri = URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/reblog")
-  else
-    uri = URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}/unreblog")
-  end
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
 
-  https = Net::HTTP.new(uri.host, uri.port)
-  https.use_ssl = true
+    req = Net::HTTP::Post.new(uri.request_uri)
 
-  req = Net::HTTP::Post.new(uri.request_uri)
+    req["Authorization"] = "Bearer #{account[:token]}"
 
-  token = " Bearer " + account[:token]
-
-  req["Authorization"] = token
-
-
-  res = https.request(req)
-
-  mikutodon_is_error?(res, "reblog")
-  # activity :mikutodon_debug_message, "reblog: #{res.code} #{res.message}"
+    https.request(req)
+  }.next { |res|
+    mikutodon_is_error?(res, "reblog")
+    # activity :mikutodon_debug_message, "reblog: #{res.code} #{res.message}"
+  }
 end
 
 def toot_test(id, account)
-  uri = URI.parse("https://#{account[:host]}/api/v1/statuses/#{id}")
-  token = " Bearer " + account[:token]
+  Thread.new(id, account) { |status_id, acct|
+    uri = URI.parse("https://#{acct[:host]}/api/v1/statuses/#{status_id}")
+    token = "Bearer #{acct[:token]}"
 
-  https = Net::HTTP.new(uri.host, uri.port)
-  https.use_ssl = true
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
 
-  req = Net::HTTP::Get.new(uri.path)
-  req["Authorization"] = token
+    req = Net::HTTP::Get.new(uri.path)
+    req["Authorization"] = token
 
-  res = https.request(req)
-
-  return  ({'code' => res.code,
-            'message' => res.message,
-            'body' => JSON.parse(res.body)})
-
+    https.request(req)
+  }.next { |res|
+    {
+      code: res.code,
+      message: res.message,
+      body: JSON.parse(res.body)
+    }
+  }
 end
 
 
 def post_toot(text, cw, account, config)
-  vis =
-    case config
-      when 0 then
-        vis = "public"
-      when 1 then
-        vis = "unlisted"
-      when 2 then
-        vis = "private"
-      when 3 then
-        vis = "direct"
-      when 4 then
-        case rand(1..400)
-        when 1..100 then
-          vis = "public"
-        when 101..200 then
-          vis = "unlisted"
-        when 201..300  then
-          vis = "private"
-        when 301..400 then
-          vis = "direct"
-        else
-          activity :mikutodon_debug_message, "0から3までの乱数が0から3以外の数値を出したよ！\nすごいね！どう考えてもバグだね！"
-        end
-      else
-        vis = "public"
-      end
+  Thread.new(text, cw, account, config) { |post_text, contents_w, acct, conf|
+    vis = case conf
+          when 0 then
+            "public"
+          when 1 then
+            "unlisted"
+          when 2 then
+            "private"
+          when 3 then
+            "direct"
+          when 4 then
+            random_vis
+          else
+            "public"
+          end
 
-  uri = URI.parse("https://#{account[:host]}/api/v1/statuses")
-  https = Net::HTTP.new(uri.host, uri.port)
-  https.use_ssl = true
+    uri = URI.parse("https://#{acct[:host]}/api/v1/statuses")
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
 
-  req = Net::HTTP::Post.new(uri.request_uri)
+    req = Net::HTTP::Post.new(uri.request_uri)
 
-  data = {
-    status: text,
-    visibility: vis,
-    spoiler_text: cw
-  }.to_json
+    data = {
+      status: post_text,
+      visibility: vis,
+      spoiler_text: contents_w
+    }.to_json
 
-  token = " Bearer " + account[:token]
+    req["Content-Type"] = "application/json"
+    req["Authorization"] = "Bearer #{acct[:token]}"
 
-  req["Content-Type"] = "application/json"
-  req["Authorization"] = token
+    req.body = data
 
-  req.body = data
-
-  res = https.request(req)
-
-  $toot_result = res.body
-  mikutodon_is_error?(res, "toot")
-  # activity :mikutodon_debug_message, "toot: #{res.code} #{res.message}"
-
+    https.request(req)
+  }.next { |res|
+    $toot_result = res.body
+    mikutodon_is_error?(res, "toot")
+    # activity :mikutodon_debug_message, "toot: #{res.code} #{res.message}"
+  }
 end
 
 def mikutodon_is_error?(res, type)
@@ -131,3 +115,17 @@ def mikutodon_is_error?(res, type)
   end
 end
 
+def random_vis
+  case rand(1..400)
+  when 1..100 then
+    "public"
+  when 101..200 then
+    "unlisted"
+  when 201..300  then
+    "private"
+  when 301..400 then
+    "direct"
+  else
+    activity :mikutodon_debug_message, "0から3までの乱数が0から3以外の数値を出したよ！\nすごいね！どう考えてもバグだね！"
+  end
+end


### PR DESCRIPTION
toot_operationのメソッドを[Delayer::Deferred](https://github.com/toshia/delayer-deferred)を返すようにしてみました  
これによって非同期なメソッドの取扱がmikutterのコアと同じになり扱いやすくなったはず。  
あとはDelayer::Deferredの `trap` ブロックでエラーを処理できるようになり、mikutterそのものが落ちることは減ったと思います。どうハンドルするかはまだ決まっていないようでしたので、ひとまず
 `error` でコンソールのログに出すようにしておきました。　　

ついでに `post_toot` のsuccessブロックで投稿欄のバッファをクリアするようにしました。
これによって失敗時は投稿ボックスのバッファをクリアされません。
成功時も失敗時もバッファをクリアする場合は以下のように記述すればいいです。
```ruby
post_toot(text, cw, account, UserConfig[:mastodon_vis]).next {
    # 成功時の処理
}.trap { |err|
    # エラー時の処理
    error err
}.next {
    # finallyブロックになる
    # 投稿成功時のみバッファをクリア
    Plugin.create(:gtk).widgetof(opt.widget).widget_post.buffer.text = ""
}
```
Delayer::Deferredの仕様で、 `trap` ブロックのあとに `next` ブロックを続けた場合は `finally` になります。（成功時、エラー時に関わらず必ず実行される）